### PR TITLE
Fixes getEntity types.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1019,7 +1019,7 @@ declare namespace Draft {
         static create(): CharacterMetadata;
 
         getStyle(): DraftInlineStyle;
-        getEntity(): string;
+        getEntity(): string | null;
         hasStyle(style: string): boolean;
       }
 


### PR DESCRIPTION
**What:**
Adds `null` to return type of `CharacterMetadata.getEntity`.